### PR TITLE
Gave the Name Generator some love

### DIFF
--- a/src/main/java/com/faforever/gw/services/generator/CharacterNameGenerator.java
+++ b/src/main/java/com/faforever/gw/services/generator/CharacterNameGenerator.java
@@ -241,25 +241,25 @@ public class CharacterNameGenerator {
 		case CYBRAN:
 			double humanName = Math.random();
 			if (humanName < 0.5) {
-				String name = symbiontNames[(int) (Math.random() * symbiontNames.length)];
-				String surname = symbiontSurnames[(int) (Math.random() * symbiontSurnames.length)];
+				name = symbiontNames[(int) (Math.random() * symbiontNames.length)];
+				surname = symbiontSurnames[(int) (Math.random() * symbiontSurnames.length)];
 				if(findString(surname, blacklistNames)) return generateName(faction);
 				return name + " " + surname;
 			} else {
-				String machineName = symbionyAI[(int) (Math.random() * symbiontAI.length)];
+				String machineName = symbiontAI[(int) (Math.random() * symbiontAI.length)];
 				int idNumber = (int) (5 + Math.random() * 15);
-				String name = machineName + "-" + idNumber;
+				name = machineName + "-" + idNumber;
 				if(findString(name, blacklistNames)) return generateName(faction);
 				return name;
 			}
 		case AEON:
-			String name = aeonNames[(int) (Math.random() * aeonNames.length)];
+			name = aeonNames[(int) (Math.random() * aeonNames.length)];
 			String epithet = aeonEpithets[0][(int) (Math.random() * aeonEpithets[0].length)];
 			String virtue = aeonEpithets[1][(int) (Math.random() * aeonEpithets[1].length)];
 			if(findString(name, blacklistNames)) return generateName(faction);
 			return name + ", " + epithet + " of " + virtue;
 		case SERAPHIM:
-			String name = makeSeraphimName() + "-" + makeSeraphimName();
+			name = makeSeraphimName() + "-" + makeSeraphimName();
 			if(findString(name, blacklistNames)) return generateName(faction);
 			return name;
 		}

--- a/src/main/java/com/faforever/gw/services/generator/CharacterNameGenerator.java
+++ b/src/main/java/com/faforever/gw/services/generator/CharacterNameGenerator.java
@@ -238,13 +238,9 @@ public class CharacterNameGenerator {
 		return null;
 	}
 
-	/* Creates a list of names for a certain faction. Obviously takes a faction argument to determine the faction, and 
-	 * takes an integer argument to determine the size of the output list. Can be used to offer a list of names for
-	 * selection during GW character creation.	
-	 */
-	public String[] generateNames(Faction faction, int amount){
-		String[] list = new String[amount];
-		for(int i = 0; i < amount; i++){
+	public String[] generateNames(Faction faction){
+		String[] list = new String[5];
+		for(int i = 0; i < list.length; i++){
 			list[i] = generateName(faction);
 		}
 		return list;

--- a/src/main/java/com/faforever/gw/services/generator/CharacterNameGenerator.java
+++ b/src/main/java/com/faforever/gw/services/generator/CharacterNameGenerator.java
@@ -235,6 +235,7 @@ public class CharacterNameGenerator {
 		case SERAPHIM:
 			return (makeSeraphimName() + "-" + makeSeraphimName());
 		}
+		return null;
 	}
 
 	/* Creates a list of names for a certain faction. Obviously takes a faction argument to determine the faction, and 

--- a/src/main/java/com/faforever/gw/services/generator/CharacterNameGenerator.java
+++ b/src/main/java/com/faforever/gw/services/generator/CharacterNameGenerator.java
@@ -234,32 +234,32 @@ public class CharacterNameGenerator {
 		int index1, index2, index3;
 		switch (faction) {
 		case UEF:
-			name = earthNames[(int) (Math.random() * earthNames.length)];
-			surname = earthSurnames[(int) (Math.random() * earthSurnames.length)];
+			String name = earthNames[(int) (Math.random() * earthNames.length)];
+			String surname = earthSurnames[(int) (Math.random() * earthSurnames.length)];
 			if(findString(surname, blacklistNames)) return generateName(faction);
 			return name + " " + surname;
 		case CYBRAN:
 			double humanName = Math.random();
 			if (humanName < 0.5) {
-				name = symbiontNames[(int) (Math.random() * symbiontNames.length)];
-				surname = symbiontSurnames[(int) (Math.random() * symbiontSurnames.length)];
+				String name = symbiontNames[(int) (Math.random() * symbiontNames.length)];
+				String surname = symbiontSurnames[(int) (Math.random() * symbiontSurnames.length)];
 				if(findString(surname, blacklistNames)) return generateName(faction);
 				return name + " " + surname;
 			} else {
-				machineName = symbionyAI[(int) (Math.random() * symbiontAI.length)];
-				idNumber = (int) (5 + Math.random() * 15);
-				name = machineName + "-" + idNumber;
+				String machineName = symbionyAI[(int) (Math.random() * symbiontAI.length)];
+				int idNumber = (int) (5 + Math.random() * 15);
+				String name = machineName + "-" + idNumber;
 				if(findString(name, blacklistNames)) return generateName(faction);
 				return name;
 			}
 		case AEON:
-			name = aeonNames[(int) (Math.random() * aeonNames.length)];
-			epithet = aeonEpithets[0][(int) (Math.random() * aeonEpithets[0].length)];
-			virtue = aeonEpithets[1][(int) (Math.random() * aeonEpithets[1].length)];
+			String name = aeonNames[(int) (Math.random() * aeonNames.length)];
+			String epithet = aeonEpithets[0][(int) (Math.random() * aeonEpithets[0].length)];
+			String virtue = aeonEpithets[1][(int) (Math.random() * aeonEpithets[1].length)];
 			if(findString(name, blacklistNames)) return generateName(faction);
 			return name + ", " + epithet + " of " + virtue;
 		case SERAPHIM:
-			name = makeSeraphimName() + "-" + makeSeraphimName();
+			String name = makeSeraphimName() + "-" + makeSeraphimName();
 			if(findString(name, blacklistNames)) return generateName(faction);
 			return name;
 		}

--- a/src/main/java/com/faforever/gw/services/generator/CharacterNameGenerator.java
+++ b/src/main/java/com/faforever/gw/services/generator/CharacterNameGenerator.java
@@ -12,29 +12,30 @@ public class CharacterNameGenerator {
 	private final static String[] symbiontAI;
 	private final static String[] aeonNames;
 	private final static String[][] aeonEpithets;
+	private final static String[] blacklistNames;
 
 	static {
 		earthNames = new String[]{
 				//Male names
 				"Alexander", "Albert", "Arnold", "August",//A
-				"Brad", "Bernard", "Bruce", "Baird",//B
+				"Brad", "Bernard", "Bruce", "Baird", "Brian",//B
 				"Charles", "Cole", "Christopher",//C
 				"David", "Daniel", "Dominic", "Donald",//D
 				"Edward", "Evan", "Eric", "Erich",//E
 				"Frederick", "Felix",//F
 				"Gavin", "Gregory", "Gunther", "George", "Grant", "Gordon",//G
-				"Henry", "Harrison", "Hewlett", "Hall",//H
+				"Henry", "Harrison", "Hewlett", "Hall", "Howard",//H
 				"Isaac",
 				"Jackson", "Jacob", "Johnathan", "James",//J
 				"Kevin", "Kendall",//K
 				"Lewis", "Logan", "Lucius", "Leonard",//L
-				"Marcus", "Maddox", "Maverick", "Mathias", "Matthew", "Michael","Mitchel", //M
+				"Marcus", "Maverick", "Mathias", "Matthew", "Michael","Mitchel", //M
 				"Nicholai", "Nadir", "Noah", "Nigel",//N
 				"Octavius", "Oberon",//O
 				"Paul", "Percival", "Percius", "Peter",//P
 				"Quentin", "Quinlan",//Q
 				"Randall", "Raymond", "Richard", "Robin",//R
-				"Stephen", "Sergey", "Stanislav", "Steven", "Samuel","Scott",//S
+				"Stephen", "Sergey", "Stanislav", "Steven", "Samuel","Scott", "Shane",//S
 				"Tony", "Trent", "Tyler", "Thomas", "Terrence",//T
 				"Umberto",//U
 				"Victor", "Vladimir",//V
@@ -72,7 +73,7 @@ public class CharacterNameGenerator {
 				"Shelby", "Sessions", "Begich", "McCain", "Flake", "Pryor", "Bozeman", "Udall", "Bennett", "Blumenthal",
 				"Murphy", "Carper", "Coons", "Nelson", "Rubio", "Chambliss", "Isakson", "Crapo", "Risch",
 				"Kirk", "Donnelly", "Grassley", "Harkin", "Moran", "O'Connell", "Paul", "Vitter", "King", "Cardin",
-				"Warren", "Cowan", "Levin", "Franklin", "Cochran", "Wicker", "Blunt", "Baucus", "Trump", "Tester", "Johanns", "Reid",
+				"Warren", "Cowan", "Levin", "Franklin", "Cochran", "Wicker", "Blunt", "Baucus", "Tester", "Johanns", "Reid",
 				"Heller", "Burr", "Hoeven", "Portman", "Grayson", "Porter", "Perry", "McGuire", "Gardner", "Tusk", "Tustin",
 				"Coburn", "Wyden", "Merkley", "Casey", "Jr.", "Reed", "Whitehouse", "Scott", "Johnson", "Washington", "Mae",
 				"Thune", "Corker", "Cornyn", "Cruz", "Lee", "Leahy", "Warner", "Kaine", "Manchin", "Johnson",
@@ -150,7 +151,7 @@ public class CharacterNameGenerator {
 				"Herewardred", "Elfricne", "Eardic", "Leofri", "Ealdg", "Osgaric", "Ealdrarht", "Aesc",
 				"Elflaht", "Elfriae", "Aelfwric", "Leofgy", "Hild", "Eadmae", "Eadwinurg", "Aelfgiild",
 				"Rianna", "Marxon", "Katherine", "Niobe", "Gael", "Stelios", "Thrace", "Enzi", "Enel",
-				"Irime", "Miriel", "Thalia", "Aeron", "Andras", "Brenin", "Bedwyr", "Delwyn", "Emyr", "Elis",
+				"Irime", "Miriel", "Aeron", "Andras", "Brenin", "Bedwyr", "Delwyn", "Emyr", "Elis",
 				"Garreth", "Glynn", "Harri", "Iwan", "Loyd", "Macsen", "Marlin", "Teigan", "Tristore", "Anika", 
 				"Wilona", "Ioanna", "Kyros", "Maris", "Thea", "Thanos", "Theo", "Yanni", "Cara", "Emrys", "Mavis",
 				"Muriel", "Morrigan", "Neale", "Nyle", "Orin", "Reagan", "Sloan", "Tristian", "Teyrnon", "Wynne",
@@ -158,7 +159,7 @@ public class CharacterNameGenerator {
 				"Naxos", "Mace", "Halmar", "Horus", "Neldor", "Cormac", "Taog", "Maol", "Arailt", "Tanovar", "Eirmer",
 				"Jonas", "Johannas", "Paeris", "Faelyn", "Rhun", "Caerau", "Medyr", "Eurion", "Gawain", "Aidan",
 				"Dabriel", "Zachriel", "Haniel", "Forcas", "Ezekiel", "Tagas", "Ithuriel", "Arioch", "Tadhiel",
-				"Alaion", "Maul", "Aron", "Sheelin", "Aodh", 
+				"Alaion", "Maul", "Aron", "Sheelin", "Aodh", "Levi",
 		};
 
 		//Index 0 = epithets, index 1 = virtues ([0] " of "  [1])
@@ -176,7 +177,19 @@ public class CharacterNameGenerator {
 				"the Ethereal", "Righteousness", "Redemption", "Deliverence", "Discipline", "Sacrifice", "Judgement", "Rectitude",
 				"Virtue", "Absolution", 
 			}
-		}; 
+		};
+		
+		//Full names and surnames from characters in Supreme Commander plot that are blacklisted for GW
+		blacklistNames = new String[]{
+			//Supreme Commander
+			"Min", "Jericho", "Mach", "Berry", "Eris", "Riley", "Arnold", "Clarke", "Ariel", "Brackman", "Dostya", "Eliott", "QAI",
+			"Aiko", "Toth", "Burke", "Marxon", 
+			//Supreme Commander Forged Alliance
+			"Hex5", "Hex 5", "Hex-5", "Seth-Iavow", "Shun-Ullevash", "Thel-Uuthow", "Zan-Aishahesh", "Oum-Eoshi",
+			"Kael", "Rhiza", "Hall", "Fletcher", 
+			//Supreme Commander 2
+			"Maddox", "Gauge", "Rodgers",
+		};
 	}
 
 
@@ -202,44 +215,60 @@ public class CharacterNameGenerator {
 		}
 		return str;
 	}
+	
+	// A simple helper-method to see if a string exists in a given array of strings.
+	public static boolean findString(String str, String[] list){
+		for(int i = 0; i < list.length; i++){
+			if(list[i].equals(str)) return true;
+		}
+		return false;
+	}
 
 	/* Returns a String of a random name for a given faction. Human factions have roughly a 50/50 chance of being male or female
 	 * UEF names consist of a name and surname, pulled from a pool of western culture names (with a balance of male and female names).
 	 * Cybran names have a 50/50 chance of being (human name, human surname), or (Machine name - ID number). Human cybran names come from Russian and German
-	 * cultures. Aeon names consist of a single name and epithet  in the format "(name), (epithet) of (virtue)" to vary them from other other the human factions 
+	 * cultures. Aeon names consist of a single name and epithet in the format "(name), (epithet) of (virtue)" to vary them from other other the human factions 
 	 * and to emphasize their fanaticism. Seraphim names are generated from scratch in two pieces in the format  "(name)-(name)".
 	 */
 	public String generateName(Faction faction) {
 		int index1, index2, index3;
 		switch (faction) {
 		case UEF:
-			index1 = (int) (Math.random() * earthNames.length);
-			index2 = (int) (Math.random() * earthSurnames.length);
-			return earthNames[index1] + " " + earthSurnames[index2];
+			name = earthNames[(int) (Math.random() * earthNames.length)];
+			surname = earthSurnames[(int) (Math.random() * earthSurnames.length)];
+			if(findString(surname, blacklistNames) return generateName(faction);
+			return name + " " + surname;
 		case CYBRAN:
 			double humanName = Math.random();
 			if (humanName < 0.5) {
-				index1 = (int) (Math.random() * symbiontNames.length);
-				index2 = (int) (Math.random() * symbiontSurnames.length);
-				return symbiontNames[index1] + " " + symbiontSurnames[index2];
+				name = symbiontNames[(int) (Math.random() * symbiontNames.length)];
+				surname = symbiontSurnames[(int) (Math.random() * symbiontSurnames.length)];
+				if(findString(surname, blacklistNames) return generateName(faction);
+				return name + " " + surname;
 			} else {
-				index1 = (int) (Math.random() * symbiontAI.length);
-				index2 = (int) (5 + Math.random() * 15);
-				return symbiontAI[index1] + "-" + index2;
+				machineName = symbionyAI[(int) (Math.random() * symbiontAI.length)];
+				idNumber = (int) (5 + Math.random() * 15);
+				name = machineName + "-" + idNumber;
+				if(findString(name, blacklistNames) return generateName(faction);
+				return name;
 			}
 		case AEON:
-			index1 = (int) (Math.random() * aeonNames.length);
-			index2 = (int) (Math.random() * aeonEpithets[0].length);
-			index3 = (int) (Math.random() * aeonEpithets[1].length);
-			return aeonNames[index1] + ", " + aeonEpithets[0][index2] + " of " + aeonEpithets[1][index3];
+			name = aeonNames[(int) (Math.random() * aeonNames.length)];
+			epithet = aeonEpithets[0][(int) (Math.random() * aeonEpithets[0].length)];
+			virtue = aeonEpithets[1][(int) (Math.random() * aeonEpithets[1].length)];
+			if(findString(name, blacklistNames)) return generateName(faction);
+			return name + ", " + epithet + " of " + virtue;
 		case SERAPHIM:
-			return (makeSeraphimName() + "-" + makeSeraphimName());
+			name = makeSeraphimName() + "-" + makeSeraphimName();
+			if(findString(name, blacklistNames)) return generateName(faction);
+			return name;
 		}
 		return null;
 	}
 
+	
 	public String[] generateNames(Faction faction){
-		String[] list = new String[5];
+		String[] list = new String[5];  
 		for(int i = 0; i < list.length; i++){
 			list[i] = generateName(faction);
 		}

--- a/src/main/java/com/faforever/gw/services/generator/CharacterNameGenerator.java
+++ b/src/main/java/com/faforever/gw/services/generator/CharacterNameGenerator.java
@@ -5,150 +5,248 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class CharacterNameGenerator {
-    private final static String[] names;
-    private final static String[] lastNames;
-    private final static String[] machineParts;
-    private final static String[] aeonNames;
-    private final static String[] seraNameParts;
+	private final static String[] earthNames;
+	private final static String[] earthSurnames;
+	private final static String[] symbiontNames;
+	private final static String[] symbiontSurnames;
+	private final static String[] symbiontAI;
+	private final static String[] aeonNames;
+	private final static String[][] aeonEpithets;
 
-    static {
-        names = new String[]{
-                //Male names
-                "Alexander", "Albert", "Arnold",//A
-                "Brad", "Bernard", "Boris",//B
-                "Charles", "Cole",//C
-                "David", "Daniel", "Dominic",//D
-                "Edward", "Evan", "Eric", "Erich",//E
-                "Frederick", "Felix",//F
-                "Gavin", "Gregory", "Gunther", "George",//G
-                "Henry", "Harrison", "Heinz", "Hans",//H
-                "Ivan", "Igor",//I
-                "Jack", "Jacob",//J
-                "Kevin", "Kendall",//K
-                "Lewis", "Logan",//L
-                "Mark", "Maddox",//M
-                "Nicholai", "Nadir",//N
-                "Octavius", "Otto",//O
-                "Paul", "Percival",//P
-                "Quentin", "Quinlan",//Q
-                "Randall", "Raymond",//R
-                "Stephen", "Sergey", "Stanislav", "Steve",//S
-                "Tony", "Trent",//T
-                "Umberto",//U
-                "Victor", "Vlad",//V
-                "Wyatt", "Walter", "Wagner,", "William",//W
-                //X
-                "Yuri", "Yevgeny",//Y
-                "Zane", "Zachary",//Z
-                //Female names
-                "Alice", "Aiko", "Abigail", "Alexandra",//A
-                "Beatrice",//B
-                "Claire", "Caroline",//C
-                "Dasha", "Devon",//D
-                "Elizabeth", "Emily",//E
-                "Felicia", "Fiona",//F
-                "Gabriella", "Grace",//G
-                "Hannah", "Heather",//H
-                "Isabella", "Irene",//I
-                "Juliana", "Jennifer",//J
-                "Kelsey", "Kathleen", "Katherine",//K
-                "Lena", "Lyudmila",//L
-                "Mackenzie", "Michelle",//M
-                "Nicole", "Natalia",//N
-                "Olivia", "Oksana",//O
-                "Paula", "Patricia",//P
-                //Q
-                "Rochelle", "Raven",//R
-                "Sofia", "Sasha",//S
-                "Tiffany", "Thalia",//T
-                "Ulyana",//U
-                "Victoria", "Vanessa",//V
-                "Winnifred", "Wilhelmina",//W
-                //X
-                "Yulia", "Yana",//Y
-                "Zoe", "Zara",//Z
-        };
+	static {
+		earthNames = new String[]{
+				//Male names
+				"Alexander", "Albert", "Arnold", "August",//A
+				"Brad", "Bernard", "Bruce", "Baird",//B
+				"Charles", "Cole", "Christopher",//C
+				"David", "Daniel", "Dominic", "Donald",//D
+				"Edward", "Evan", "Eric", "Erich",//E
+				"Frederick", "Felix",//F
+				"Gavin", "Gregory", "Gunther", "George", "Grant", "Gordon",//G
+				"Henry", "Harrison", "Hewlett", "Hall",//H
+				"Isaac",
+				"Jackson", "Jacob", "Johnathan", "James",//J
+				"Kevin", "Kendall",//K
+				"Lewis", "Logan", "Lucius", "Leonard",//L
+				"Marcus", "Maddox", "Maverick", "Mathias", "Matthew", "Michael","Mitchel", //M
+				"Nicholai", "Nadir", "Noah", "Nigel",//N
+				"Octavius", "Oberon",//O
+				"Paul", "Percival", "Percius", "Peter",//P
+				"Quentin", "Quinlan",//Q
+				"Randall", "Raymond", "Richard", "Robin",//R
+				"Stephen", "Sergey", "Stanislav", "Steven", "Samuel","Scott",//S
+				"Tony", "Trent", "Tyler", "Thomas", "Terrence",//T
+				"Umberto",//U
+				"Victor", "Vladimir",//V
+				"Wyatt", "Walter", "William", "Winston",//W
+				"Xavier", //X
+				"Zane", "Zachary",//Z
+				//Female names
+				"Alice", "Aiko", "Abigail", "Alexandra", "Amelia", "Ava", "Annabelle", "Avery",
+				"Beatrice", "Brynn", "Briana",//B
+				"Claire", "Caroline", "Catherine", "Colette", "Chloe", "Cassidy", "Camille",//C
+				"Dasha", "Devon", "Dietrich", "Delaney", "Dakota", "Diana",//D
+				"Elizabeth", "Emily", "Elena", "Evelyn", "Ella", "Emma",//E
+				"Felicia", "Fiona",//F
+				"Gabriella", "Grace", 
+				"Hannah", "Heather", "Holly",//H
+				"Isabella", "Irene", 
+				"Juliana", "Jennifer", "Jillian",//J
+				"Kelsey", "Kathleen", "Katherine", "Kristen",//K
+				"Lena", "Lyudmila", "Lucy",//L
+				"Mackenzie", "Michelle", "Mariane", "Maya", "Madeline", "Miriam", "Macy", "Marina", //M
+				"Nicole", "Natalia", "Niobe", "Naomi", "Nina",//N
+				"Olivia", "Oksana", "Olga",//O
+				"Paula", "Patricia", "Penelope", "Paisley", "Piper", "Polina",//P
+				//Q
+				"Rochelle", "Raven", "Riley", "Rebecca", "Rachell", //R
+				"Sofia", "Sasha", "Sadie",//S
+				"Tabitha", "Thalia", "Taylor", "Tatyana",//T
+				"Ulyana",//U
+				"Victoria", "Vanessa", "Violet", "Valyria",//V
+				"Winnifred", 
+				//X
+		};
 
-        lastNames = new String[]{
-                "Shelby", "Sessions", "Begich", "McCain", "Flake", "Pryor", "Bozeman", "Udall", "Bennett", "Blumenthal",
-                "Murphy", "Carper", "Coons", "Nelson", "Rubio", "Chambliss", "Isakson", "Schatz", "Crapo", "Risch",
-                "Kirk", "Coats", "Donnelly", "Grassley", "Harkin", "Moran", "O'Connell", "Paul", "Vitter", "King", "Cardin",
-                "Warren", "Cowan", "Levin", "Franken", "Cochran", "Wicker", "Blunt", "Baucus", "Tester", "Johanns", "Reid",
-                "Heller", "Lautenberg", "Menendez", "Udall", "Heinrich", "Schumer", "Burr", "Hoeven", "Portman", "Inhofe",
-                "Coburn", "Wyden", "Merkley", "Casey, Jr.", "Reed", "Whitehouse", "Scott", "Johnson", "Washington", "Mae",
-                "Thune", "Corker", "Cornyn", "Cruz", "Lee", "Leahy", "Warner", "Kaine", "Manchin", "Johnson", "Enzi",
-                "Barrasso", "Rokossovsky", "Model", "von Manstein"
-        };
+		earthSurnames = new String[]{
+				"Shelby", "Sessions", "Begich", "McCain", "Flake", "Pryor", "Bozeman", "Udall", "Bennett", "Blumenthal",
+				"Murphy", "Carper", "Coons", "Nelson", "Rubio", "Chambliss", "Isakson", "Crapo", "Risch",
+				"Kirk", "Donnelly", "Grassley", "Harkin", "Moran", "O'Connell", "Paul", "Vitter", "King", "Cardin",
+				"Warren", "Cowan", "Levin", "Franklin", "Cochran", "Wicker", "Blunt", "Baucus", "Trump", "Tester", "Johanns", "Reid",
+				"Heller", "Burr", "Hoeven", "Portman", "Grayson", "Porter", "Perry", "McGuire", "Gardner", "Tusk", "Tustin",
+				"Coburn", "Wyden", "Merkley", "Casey", "Jr.", "Reed", "Whitehouse", "Scott", "Johnson", "Washington", "Mae",
+				"Thune", "Corker", "Cornyn", "Cruz", "Lee", "Leahy", "Warner", "Kaine", "Manchin", "Johnson",
+				"Barrasso", "Rokossovsky", "Model", "Satchel", "Antony", "Graff", "Thatcher", "Cicero", "Benedict",
+				"Bismark", "Berling", "Randolph", "Brutus", "Mattis", "Dunford", "Ford", "Petrov", "Pershing", "Reinhardt",
+				"Mansfeld", "Harvey", "Kennedy", "Schulte", "Wolf", "Mackenzie", "O'Reilly", "Graham", "Owens",
+				"Fisher", "Reynolds", "Ferguson", "Hamilton", "Schmidt", "Andrews", "Silva", "Davidson", "Hoffman", "Maxwell", "Floyd",
+				"Santana", "Clayton", "Dalton", "Preston", "Booker", "Wilkinson", "Maynard", "Sloan", "Browning", "Winters", "Durham", "Bradshaw",
+				"Rivers", "Bartlett", "Goodell", "Sheppard", "Kimball", "Barron", "Pennington", "Macintosh", "Harding", "Hoover", "Richmond", 
+				"Neller", "Dickinson", "Grayson", "Adams", "Webster", "Stonewall", "Hickery", "Stout", "Lynn", "Mccarthy", "Sears", "Donovan",
+				"Stanton", "Lancaster", "Tyson", "Sharpe", "Whitfield", "Stuart", "Conrad", "Kirkland", "Carney", "Hyde", "Vinson", "Mcmahon", 
+				"Knowles", "Morrison", "Hudson", "Matthews", "Dunn", "Stone", "Dixon", "Crawford", "Hunter", "Webb", "Mason", "Warden", "Shaw", 
+				"Robertson", "Daniels", "Palmer", "Rice", "Woods", "Butler", "Price", "Watson", "Morgan", "Bell", "Lincoln", "Howard",
+				"Cook", "Campbell", "Collins", "Green", "Young", "Clarkson", "Moore", "Anderson", "Martin", "Williams", 
+		};
 
-        machineParts = new String[]{
-                "Binary", "Decimal", "Octal", "Hex", "Cipher", "Algo", //math related
-                "Circuit", "Transistor", "Capacitor", "Conductor", // electrical components
-                "Flash", "Electron", "Voltron", "Refractor", "Pulse", "Gear", "Wave", "Gauge", // physics related
-                "Core", "Processor", "Monitor", "Mainframe", "Jumper", // pc parts related
-                "iNode", "Stream", "Terminal", "Torrent", "Switch", "Link" // network related
-        };
+		symbiontNames = new String[]{
+				//German Male
+				"Oskar", "Konstantin", "Hans", "Heinrich", "Joseph", "Martin", "Konrad", "Hendrik", "Ludwig", "Archibald", "Arik", "Balwin",
+				"Baron", "Christoffer", "Dedrick", "Dolphus", "Eberhardt", "Emmett", "Eldwin", "Erich", "Eugen", "Frederic", "Garen", "Georg", "Gregor", "Griswold",
+				"Godfrey", "Gustav", "Gunther", "Hewlett", "Hildemar", "Hildagarde", "Ernst", "Otto", "Karl", "Ludolf", "Felix", "Hermann", "Artur", "Broder",
+				"Wilhelm", "Erich", "Rudolph", "Walter", "Werner", "Kurtis", "Imfried", "Rolf", "Ulrich", "Alfons", "Christoph", "Nikolaus", "Theodor", "Leopold",
+				//German Female
+				"Greta", "Frieda", "Mathilda", "Dietrich", "Angela", "Adolpha", "Adele", "Angelika","Ava", "Mathilda", "Erika", "Ethelinda", "Genevieve", "Grisella", 
+				"Harriet", "Wilma", "Irmina", "Karlina", "Karoline", "Brita", "Madeline", "Margret", "Marlene", "Monika", "Odelina", "Olinda", "Roderika", "Selma",
+				"Ulva", "Wendeline", "Wilma", "Zelma",
+				//Russian Male
+				"Abram", "Aleksy","Ivan", "Peter", "Artem", "Artyom", "Borislav", "Bronislav", "David", "Dmitri", "Nikolai", "Evgeny", "Grigori", "Isidor",
+				"Konstantin", "Leonid", "Luka", "Makar", "Mark", "Maxim", "Miron", "Miroslav", "Nestor", "Pavel", "Radimir", "Radovid", "Rolan", "Samuil", "Sergei",
+				"Vladimir", "Sevastian", "Yuri", "Yevgeny", "Yakov", "Timur", "Viktor", "Velen", "Vladislav", "Yakov", "Zakhar", "Alexander", "Mikhail", "Igor", "Evgeny",
+				"Andrei", "Pyotr", "Rotislav", "Alexei", "Zhores", 
+				//Russian Female
+				"Alexandra", "Anna", "Annastasia", "Elena", "Ivanna", "Dominika", "Eva", "Galina", "Gala", "Ilya", "Juliana", "Katerina", "Karina", "Julia",
+				"Kira", "Klara", "Kristina", "Lara", "Lidya", "Marina", "Mariya", "Masha", "Misha", "Nadya", "Natasia", "Nina", "Polina", "Olga", "Silena", 
+				"Tatyana", "Svetlana", "Yulia", "Yana", "Tanya", "Valery", "Vasilia", "Viktoria", 	
+		};
 
-        aeonNames = new String[]{
-                "Pryderudd", "Merli", "Fanbyn", "Wili", "Andrasron", "Derauned", "Trevnon", "Pric", "Cerri",
-                "Gainri", "Brynmo", "Blodeuwene", "Dallau", "Catrin", "Gwenan", "Aradoc", "Hefionmyr",
-                "Merrioale", "Morwelur", "Hefin", "Aelrewarrga", "Eadweard", "Aescorn", "Eadgar",
-                "Herewardred", "Elfricne", "Eardic", "Leofri", "Ealdg", "Osgaric", "Ealdrarht", "Aesc",
-                "Elflaht", "Elfriae", "Aelfwric", "Leofgy", "Hild", "Eadmae", "Eadwinurg", "Aelfgiild",
-                "Rianna", "Marxon", "Kathleen", "Katherine",
-        };
+		symbiontSurnames = new String[]{
+				//German names:   		
+				"von Manstein", "Wagner", "Wolff", "Bauer", "Hofmann", "Gunther", "Albrecht", "Baumann", "Friedrich", "Jager", "Pietsch",
+				"Altergott", "Andelman", "Brecher", "Beckendorf", "Beissel", "Breslau", "Ehrhardt", "Junker", "Kanitz", "Kaiser", "Kauffman", 
+				"Klock", "Klaus", "Kreuzer", "Lehr", "Lentz", "Meissner", "Moldenhauer", "Prinz", "Reichman", "Reinhardt", "Radunz", "Rossman", "Schult", 
+				"Schwarzkopf", "Selig", "Sohn", "Stauben", "Steiner", "Strobl", "Sulz", "Thalberg", "Trager", "Voss", "Vogel", "Wachter", "Wahrmann", "Wohl",
+				"Zeigler", "Zorn", "Kruger", "Friedrich", "Winter", "Brandt", "Busch", "Schroder", "Beyer", "Bodmann", "Bruckner", "Becher", "Bachman", "Eichmann",
+				"Erhard", "Bismark", "Anacker", "Goring", "Hausser", "Wilhelm", "Jaeger", "Kampf", "Kiesinger", "Kraftman", "Kohlmann", "Kern", "Macher", "Moder",
+				"Meyer", "Oberlander", "Oberg", "Reinecke", "Rainer", "Franz", "Oswald", "Schafer", "Stark", "Straube", "Oskar", "Weidenmann", "Weber",
+				"Lautenberg", "Heinrich", "Schumer", "Inhofe",
+				//Russian names:
+				"Mikhailov","Rokossovsky","Isatova","Glayanov", "Markov", "Donskoy", "Brin", 
+				"Velsky", "Durov", "Lebedev", "Lupanov", "Morozov", "Pavlov", "Stepanov", "Skylarov", "Terekov", "Turchiv", "Ternovsky", "Yablonsky",
+				"Petrov", "Chokov", "Grabin", "Khariton", "Dragunov", "Nikonov", "Petrovich", "Simonov", "Tokarev", "Korbac", "Mosin", "Conrad", 	
+				"Alexandrov", "Aristov", "Avilov", "Alenin","Bazin", "Bagrov", "Borodin", "Bolotnikov", "Blatov", "Vanzin", "Veselov", "Vetochkin", "Gorev",
+				"Garin", "Gachev", "Grekov", "Gubanov", "Golov", "Dobrianov", "Yerzov", "Yerkhov", "Zhabin", "Zherdev", "Zhukov", "Zholdin", "Ivankov", "Ibragimov",
+				"Ivkin", "Kabinov", "Kalashnik", "Korzhev", "Konnikov", "Kapustin", "Klokov", "Kolosov", "Loginovsky", "Lapotnikov", "Lesnichy", "Malinin", "Noskov",
+				"Nemtsev", "Olenev", "Obolensky", "Petrenko", "Pavlov", "Poltanov", "Puzanov", "Pogadin", "Pyatosin", "Rostov", "Repin", "Rusakov", "Rybalkin", "Ryzhov",
+				"Runov", "Rubashkin", "Romanov", "Rozovsky", "Sabitov", "Savinkov", "Saitov", "Smirnitsky", "Samorkhin", "Stepanov", "Sivakov", "Tamarkin", "Tarasov",
+				"Toporov", "Tatarov", "Tereschenko", "Tupolev", "Travinikov", "Usenko", "Frolov", "Fenenko", "Khabalov", "Khloponin", "Khalturin", "Kromov", "Khovansky", "Kholod",
+				"Khlebikov", "Tsaryov", "Tsukanov", "Chesnokov", "Chapayev", "Chkalov", "Chupov", "Cherkasov", "Chuprin", "Shirokov", "Sharapov", "Shalyapin", "Shuvalov", "Shinkso",
+				"Shurupov", "Shirinov", "Eristov", "Yugov", "Yurlov", "Yuditsky", "Yusupov", "Yurakin", "Yushkov", "Yabloklov", "Yashin"
+		};
 
-        seraNameParts = new String[]{
-                "Oshustl", "Zytuo", "Thosta", "Toohy", "Onnais", "Onautt", "Ostuat", "Zuastluo", "Yhunn", "Taussai", "Uhout",
-                "Unnaustl", "Tynnoo", "Ithous", "Ohuas", "Ottuhw", "Hithy", "Isauss", "Uthast", "Zytti", "Zisu",
-                "Saitha", "Thuti", "Sutty", "Sahwa", "Huzi", "Sittua", "Ustah", "Vynnu", "Unnauss", "Unuan", "Vithy",
-                "Oshyst", "Tuhoo", "Hooty", "Issyz", "Hussua", "Ithaust", "Yshust", "Yttuastl", "Ytun", "Yshyhw",
-                "Inuth", "Inuostl", "Uhwaush", "Ostuost", "Yenzyne", "Izys", "Hinna", "Uhauhw", "Zussu", "Ittyhw",
-                "Istluostl", "Innuaz", "Itutt", "Zizo", "Vasha", "Vaunni", "Hysta", "Utys", "Isaitt", "Ushoz", "Zustlu",
-                "Thisha", "Ohwush", "Vytou", "Thathy", "Zaisy", "Zastlu", "Ohwass", "Ihys", "Haustla", "Ynnooz", "Yssooh",
-                "Unnaunn", "Thituo", "Issuas", "Ytuastl", "Istus", "Sitou", "Ithitt", "Zithuo", "Histly", "Oshihw"
-        };
-    }
+		symbiontAI = new String[]{ 
+				"Decimal", "Octal", "Hex", "Cipher", "Algo", "Prime", "Unit", "Series",
+				"Core", "Gauge", "Probe", "Axon", "Alpha", "Terminal", "Procyon AI", "LM Unit",      
+				"Torrent", "Switch", "Link", "Nexus", "Proxy", "Cipher", "Shiva", "X-QAI",
+				"Mace", "Matrix", "Hive", "Automaton", "Prion", "Root", "Liberated AI", "Prototype",
+				"AVR", "Gamma", "Logic", "CMOS", "Octave", "Index", "Domain", "Vector", "Execution",
+				"Parameter", "Operant", "NERVE", 
+		};
+
+		aeonNames = new String[]{
+				"Pryderudd", "Merli", "Fanbyn", "Wilii", "Andrasron", "Derauned", "Trevnon", "Pric", "Cerri",
+				"Gainri", "Brynmo", "Blodeuwene", "Dallau", "Catrin", "Gwenan", "Aradoc", "Hefionmyr",
+				"Merrioale", "Morwelur", "Hefin", "Eadweard", "Aescorn", "Eadgar",
+				"Herewardred", "Elfricne", "Eardic", "Leofri", "Ealdg", "Osgaric", "Ealdrarht", "Aesc",
+				"Elflaht", "Elfriae", "Aelfwric", "Leofgy", "Hild", "Eadmae", "Eadwinurg", "Aelfgiild",
+				"Rianna", "Marxon", "Katherine", "Niobe", "Gael", "Stelios", "Thrace", "Enzi", "Enel",
+				"Irime", "Miriel", "Thalia", "Aeron", "Andras", "Brenin", "Bedwyr", "Delwyn", "Emyr", "Elis",
+				"Garreth", "Glynn", "Harri", "Iwan", "Loyd", "Macsen", "Marlin", "Teigan", "Tristore", "Anika", 
+				"Wilona", "Ioanna", "Kyros", "Maris", "Thea", "Thanos", "Theo", "Yanni", "Cara", "Emrys", "Mavis",
+				"Muriel", "Morrigan", "Neale", "Nyle", "Orin", "Reagan", "Sloan", "Tristian", "Teyrnon", "Wynne",
+				"Asmund", "Audun", "Einar", "Frode", "Geir", "Raul", "Siri", "Torben", "Tyr", "Vernon", "Vali", "Toth",
+				"Naxos", "Mace", "Halmar", "Horus", "Neldor", "Cormac", "Taog", "Maol", "Arailt", "Tanovar", "Eirmer",
+				"Jonas", "Johannas", "Paeris", "Faelyn", "Rhun", "Caerau", "Medyr", "Eurion", "Gawain", "Aidan",
+				"Dabriel", "Zachriel", "Haniel", "Forcas", "Ezekiel", "Tagas", "Ithuriel", "Arioch", "Tadhiel",
+				"Alaion", "Maul", "Aron", "Sheelin", "Aodh", 
+		}
+
+		//Index 0 = epithets, index 1 = virtues ([0] " of "  [1])
+		aeonEpithets = new String[][]{
+			{
+				"Servant", "Disciple", "Follower", "Seeker",  "Preacher", "Missionary", "Prophet", "Augur", "Herald",
+				"Vessel", "Upholder", "Guardian", "Patron", "Bulwark", "Defender", "Voice", "Messenger", "Emissary", "Harbinger", 
+				"Hero", "Spirit", "Marrow", "Bolster", "Vanguard", "Hammer", "The Axe", "Inquisitor", "The Force", "The Fire",
+				"Courier", "Vigor", "Resolve", "The Zeal", "The Ardor", "Arbiter", "Intuition", "The Passion", "Aura", "Sprite",
+				"Blade",
+			},
+			{
+				"the Light", "Purity", "The Way", "the Divine", "Holiness", "the Faith", "Conviction", "Reverence",
+				"Devotion", "Fealty", "Fortitude", "Salvation", "Radiance", "the Truth", "Grace", "Elysium", "Paragon", 
+				"the Ethereal", "Righteousness", "Redemption", "Deliverence", "Discipline", "Sacrifice", "Judgement", "Rectitude",
+				"Virtue", "Absolution", 
+			}
+		}; 
+	}
 
 
-    public String[] generateNames(Faction faction) {
-        String[] list = new String[5];
-        int rand1, rand2;
-        switch (faction) {
-            case UEF:
-                for (int i = 0; i < list.length; i++) {
-                    rand1 = (int) (Math.random() * names.length);
-                    rand2 = (int) (Math.random() * lastNames.length);
-                    list[i] = names[rand1] + " " + lastNames[rand2];
-                }
-                break;
-            case CYBRAN:
-                for (int i = 0; i < list.length; i++) {
-                    double humanName = Math.random();
-                    if (humanName < 0.5) {
-                        rand1 = (int) (Math.random() * names.length);
-                        rand2 = (int) (Math.random() * lastNames.length);
-                        list[i] = names[rand1] + " " + lastNames[rand2];
-                    } else {
-                        rand1 = (int) (Math.random() * machineParts.length);
-                        rand2 = (int) (Math.random() * 10);
-                        list[i] = machineParts[rand1] + " " + rand2;
-                    }
-                }
-                break;
-            case AEON:
-                for (int i = 0; i < list.length; i++) {
-                    rand1 = (int) (Math.random() * aeonNames.length);
-                    list[i] = aeonNames[rand1];
-                }
-                break;
-            case SERAPHIM:
-                for (int i = 0; i < list.length; i++) {
-                    rand1 = (int) (Math.random() * seraNameParts.length);
-                    rand2 = (int) (Math.random() * seraNameParts.length);
-                    list[i] = seraNameParts[rand1] + "-" + seraNameParts[rand2];
-                }
-                break;
-        }
-        return list;
-    }
+	//Sheppard's unique Seraphim name generator
+	private final static String[] firstVowel = { "O", "U", "I", "Y", "I" };
+	private final static String[] firstConsonant = { "T", "S", "Z", "Th", "H", "V" };
+	private final static String[] consonant = { "n", "t", "h", "s", "z", "th", "tt", "st", "sh", "hw", "ss", "nn", "stl", "n", "t", "h", "s", "z", "n", "t", "h", "s", "z" };
+	private final static String[] vowel = { "a", "y", "u", "o", "i","ou", "oo", "uu", "uo", "ai", "ua", "au", "u", "i","a", "y", "u", "o",}; 
+	//Redundant letters simply increase their occurance.
+
+	// Creates a single seraphim name based on alternating lists of typical vowels and consonants. Creates names that are two to five syllables long.
+	public static String makeSeraphimName(){
+		String str = "";
+		int size = 3 + (int) (Math.random() * 3);
+		boolean rand = Math.random() > 0.5;
+		if(rand) str+= firstVowel[(int) (firstVowel.length*Math.random())];
+		else str+= firstConsonant[(int) (firstConsonant.length*Math.random())];
+		rand = !rand;	
+		for(int i = 0; i < size; i++){
+			if(rand) str +=  vowel[(int) (vowel.length*Math.random())];
+			else str += consonant[(int) (consonant.length*Math.random())];
+			rand = !rand;
+		}
+		return str;
+	}
+
+	/* Returns a String of a random name for a given faction. Human factions have roughly a 50/50 chance of being male or female
+	 * UEF names consist of a name and surname, pulled from a pool of western culture names (with a balance of male and female names).
+	 * Cybran names have a 50/50 chance of being (human name, human surname), or (Machine name - ID number). Human cybran names come from Russian and German
+	 * cultures. Aeon names consist of a single name and epithet  in the format "(name), (epithet) of (virtue)" to vary them from other other the human factions 
+	 * and to emphasize their fanaticism. Seraphim names are generated from scratch in two pieces in the format  "(name)-(name)".
+	 */
+	public String generateName(Faction faction) {
+		int index1, index2, index3;
+		switch (faction) {
+		case UEF:
+			index1 = (int) (Math.random() * earthNames.length);
+			index2 = (int) (Math.random() * earthSurnames.length);
+			return earthNames[index1] + " " + earthSurnames[index2];
+		case CYBRAN:
+			double humanName = Math.random();
+			if (humanName < 0.5) {
+				index1 = (int) (Math.random() * symbiontNames.length);
+				index2 = (int) (Math.random() * symbiontSurnames.length);
+				return symbiontNames[index1] + " " + symbiontSurnames[index2];
+			} else {
+				index1 = (int) (Math.random() * symbiontAI.length);
+				index2 = (int) (5 + Math.random() * 15);
+				return symbiontAI[index1] + "-" + index2;
+			}
+		case AEON:
+			index1 = (int) (Math.random() * aeonNames.length);
+			index2 = (int) (Math.random() * aeonEpithets[0].length);
+			index3 = (int) (Math.random() * aeonEpithets[1].length);
+			return aeonNames[index1] + ", " + aeonEpithets[0][index2] + " of " + aeonEpithets[1][index3];
+		case SERAPHIM:
+			return (makeSeraphimName() + "-" + makeSeraphimName());
+		}
+	}
+
+	/* Creates a list of names for a certain faction. Obviously takes a faction argument to determine the faction, and 
+	 * takes an integer argument to determine the size of the output list. Can be used to offer a list of names for
+	 * selection during GW character creation.	
+	 */
+	public String[] generateNames(Faction faction, int amount){
+		String[] list = new String[amount];
+		for(int i = 0; i < amount; i++){
+			list[i] = generateName(faction);
+		}
+		return list;
+	}
 }
+

--- a/src/main/java/com/faforever/gw/services/generator/CharacterNameGenerator.java
+++ b/src/main/java/com/faforever/gw/services/generator/CharacterNameGenerator.java
@@ -159,7 +159,7 @@ public class CharacterNameGenerator {
 				"Jonas", "Johannas", "Paeris", "Faelyn", "Rhun", "Caerau", "Medyr", "Eurion", "Gawain", "Aidan",
 				"Dabriel", "Zachriel", "Haniel", "Forcas", "Ezekiel", "Tagas", "Ithuriel", "Arioch", "Tadhiel",
 				"Alaion", "Maul", "Aron", "Sheelin", "Aodh", 
-		}
+		};
 
 		//Index 0 = epithets, index 1 = virtues ([0] " of "  [1])
 		aeonEpithets = new String[][]{

--- a/src/main/java/com/faforever/gw/services/generator/CharacterNameGenerator.java
+++ b/src/main/java/com/faforever/gw/services/generator/CharacterNameGenerator.java
@@ -236,20 +236,20 @@ public class CharacterNameGenerator {
 		case UEF:
 			name = earthNames[(int) (Math.random() * earthNames.length)];
 			surname = earthSurnames[(int) (Math.random() * earthSurnames.length)];
-			if(findString(surname, blacklistNames) return generateName(faction);
+			if(findString(surname, blacklistNames)) return generateName(faction);
 			return name + " " + surname;
 		case CYBRAN:
 			double humanName = Math.random();
 			if (humanName < 0.5) {
 				name = symbiontNames[(int) (Math.random() * symbiontNames.length)];
 				surname = symbiontSurnames[(int) (Math.random() * symbiontSurnames.length)];
-				if(findString(surname, blacklistNames) return generateName(faction);
+				if(findString(surname, blacklistNames)) return generateName(faction);
 				return name + " " + surname;
 			} else {
 				machineName = symbionyAI[(int) (Math.random() * symbiontAI.length)];
 				idNumber = (int) (5 + Math.random() * 15);
 				name = machineName + "-" + idNumber;
-				if(findString(name, blacklistNames) return generateName(faction);
+				if(findString(name, blacklistNames)) return generateName(faction);
 				return name;
 			}
 		case AEON:


### PR DESCRIPTION
Behold, I have answered your cries! 
The big changes are:

Seraphim names are generated using Sheppard's propsed Seraphim vowel/consonant masher,  instead of a manually compiled list of names. The names generated by the new "makeSeraphimName()" method always seem to come out really well - this is much easier than [what originally looked like] an imagined list.

Aeon names are hard to find. It looked like you initially used single Aeon names (without surnames), which would have a very high chance of duplicates. I thought it would be a good idea to distinguish them by adding an epithet to the end of their names, thus adding diversity and role-play value. Of all changes, this might need some work (since depending on the words in the array, the generated name occasionally sounds awkward). However, the output of the Aeon names look very good to me overall, and I would be satisfied with its current state. 

UEF and Cybran surname lists have been considerably increased. Both the UEF and Cybran name and surname pools all have nearly 200 names each. The Cybran machine-name list likely needs more additions but I think it would be okay to have duplicates like"Hex-8" and "Hex-4" both appear in the same GW rotation. Also, a lot of people seem to think that the Cybrans have a significant German influence. I've added German names to the symbiont name pool and think they fit well with Cybran 'culture'. This also makes it easier to grow the name pool.

Trying to make your life easier,
(ShlippyShlappySlop)